### PR TITLE
Purge Cloudflare cache after a data refresh

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -305,6 +305,26 @@ jobs:
             flyctl volumes destroy "$OLDVOL" -y
           fi
 
+      # The edge caches data-derived pages (the homepage's database list,
+      # table row counts, etc.) with a 1-year cdn-cache-control keyed by
+      # the datasette version — which a data-only refresh doesn't bump. So
+      # a refresh that adds/changes data (or a whole database) is invisible
+      # at the edge until purged. deploy.yml purges on code deploys; this
+      # is the matching purge for data deploys.
+      - name: Purge Cloudflare cache
+        if: env.PROMOTE == 'true'
+        env:
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+        run: |
+          response=$(curl -fsS -X POST \
+            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}')
+          echo "$response"
+          echo "$response" | grep -q '"success":true' || { echo "Purge failed"; exit 1; }
+
       # ─── Teardown of staging if not promoted (dry-run + failure path) ─
 
       - name: Tear down staging


### PR DESCRIPTION
`refresh-data.yml` changes the served data — new rows, changed tables, even whole new databases (lm30) — but never purged the edge. The `cdn_cache` plugin sets `cdn-cache-control: max-age=31536000` and caches data-derived pages (the homepage's database list, table row counts) keyed by the *datasette version*, which a data-only refresh doesn't bump. So refreshed data stays invisible at the edge for up to a year until a code deploy happens to purge.

`deploy.yml` already purges on code deploys; this adds the matching `purge_everything` to `refresh-data.yml` after promotion (gated on `PROMOTE == 'true'`, same secrets).

Concretely: this is why lm30 wasn't listed on `labordata.bunkum.us/` even though `/lm30` served fine and datasette's own db list included it — the homepage was a 7-hour-old Cloudflare HIT from before lm30 was loaded, and the refresh that loaded it didn't purge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)