### PR TITLE
Fix sticky table header drifting out of alignment on horizontal scroll

### DIFF
--- a/datasette.yml
+++ b/datasette.yml
@@ -2,7 +2,7 @@ extra_css_urls:
   - /static/custom.css
 
 extra_js_urls:
-  - /static/sticky-thead.js?v=3
+  - /static/sticky-thead.js?v=4
 
 plugins:
   datasette-block-robots:

--- a/datasette.yml
+++ b/datasette.yml
@@ -1,5 +1,5 @@
 extra_css_urls:
-  - /static/custom.css
+  - /static/custom.css?v=1
 
 extra_js_urls:
   - /static/sticky-thead.js?v=4

--- a/static/custom.css
+++ b/static/custom.css
@@ -299,6 +299,15 @@ a:active {
   margin: 0;
   background: transparent;
 }
+/* sticky-thead.js sizes each cloned <th> by assigning the original th's
+   getBoundingClientRect().width — a border-box measurement. The cells default
+   to box-sizing: content-box, so that width gets padding (~25px) + border (1px)
+   added on top, inflating every column by ~26px. The error accumulates across
+   columns, so the cloned header drifts progressively left of the body as you
+   scroll right (issue #28). Match the measurement's box model. */
+.sticky-thead-clone th {
+  box-sizing: border-box;
+}
 
 
 table {

--- a/static/sticky-thead.js
+++ b/static/sticky-thead.js
@@ -50,6 +50,12 @@
       cloneTable.style.width = table.getBoundingClientRect().width + 'px';
     }
 
+    // The wrapper carries a 1px border and the table's content sits inside it.
+    // Anchor the clone to the wrapper's content box (not its border box) and
+    // clip to the visible content width, or the cloned header sits 1px left of
+    // the body — a seam that flickers as the clone toggles on/off (issue #28).
+    const borderLeft = parseFloat(getComputedStyle(wrapper).borderLeftWidth) || 0;
+
     function syncPosition() {
       const wrapRect = wrapper.getBoundingClientRect();
       const tableRect = table.getBoundingClientRect();
@@ -58,8 +64,8 @@
       // viewport and the table itself is still on-screen.
       const visible = tableRect.top < 0 && tableRect.bottom > theadHeight;
       holder.style.visibility = visible ? 'visible' : 'hidden';
-      holder.style.left = wrapRect.left + 'px';
-      holder.style.width = wrapRect.width + 'px';
+      holder.style.left = (wrapRect.left + borderLeft) + 'px';
+      holder.style.width = wrapper.clientWidth + 'px';
       holder.scrollLeft = wrapper.scrollLeft;
     }
 


### PR DESCRIPTION
## Problem

The sticky `<thead>` clone (`static/sticky-thead.js`) drifted progressively to the left of the body columns as you scrolled a wide table right — the further right a column, the worse the misalignment. Reported in #28.

## Root causes

1. **Accumulating drift.** The clone cells defaulted to `box-sizing: content-box`, but the script sizes each one with `getBoundingClientRect().width` — a *border-box* measurement. The browser then added each cell's padding (~25px) + border (1px) on top, inflating every column by ~26px. Across ~16 columns the clone table ended up ~444px wider than the real table (measured 3495px vs 3051px), so syncing `scrollLeft` couldn't keep the columns aligned.

2. **1px seam.** The clone was anchored to the wrapper's *border-box* left and given its border-box width, but the table content starts one border-width inside the wrapper. That left a constant 1px offset, visible as a flicker when the clone toggled on/off.

## Fix

- `static/custom.css`: force `.sticky-thead-clone th { box-sizing: border-box; }` so the measurement's box model matches.
- `static/sticky-thead.js`: anchor the clone to the wrapper's content box (`wrapRect.left + borderLeft`) and clip to `clientWidth`.
- `datasette.yml`: bump `sticky-thead.js?v=3` → `?v=4` so the change isn't served stale from cache.

## Verification

Measured live against `nlrb/filing` with the table scrolled right and the clone visible:

- **Before:** per-column drift accumulated `-1, +25, +51, +77, +103, +129…px`.
- **After:** **0px drift across all 16 columns**, no 1px seam.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)