### PR TITLE
query page: stream the CSV download (match table.html)

### DIFF
--- a/templates/query.html
+++ b/templates/query.html
@@ -92,7 +92,7 @@
 <div class="download-card">
     <h3>Download this data</h3>
     <p>
-        <a class="download-link" href="{{ url_csv }}{{ '&' if '?' in url_csv else '?' }}_dl=1">CSV</a>
+        <a class="download-link" href="{{ url_csv }}{{ '&' if '?' in url_csv else '?' }}_dl=1{% if settings.allow_csv_stream %}&_stream=on{% endif %}">CSV</a>
         {%- for name, url in renderers.items() -%}
             &nbsp;&middot;&nbsp;<a class="download-link" href="{{ url }}">{{ name|upper }}</a>
         {%- endfor -%}


### PR DESCRIPTION
The custom-SQL query page's CSV download link lacked the &_stream=on that table.html already adds, so large query exports went through the non-streaming path and were capped by max_csv_mb instead of streaming all rows via the server-side cursor. Append _stream=on (gated on settings.allow_csv_stream), identical to the table-view CSV link.


Claude-Session: https://claude.ai/code/session_01EVnd5NzxzY9mfrEYjmYRdN