### PR TITLE
duckdb refresh: volume retry, wget -O overwrite, 300s smoke + catalog diagnostic

### DIFF
--- a/.github/workflows/refresh-data-duckdb.yml
+++ b/.github/workflows/refresh-data-duckdb.yml
@@ -293,14 +293,47 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
+          # On this Fly setup the shared-CPU "machine capacity hold" is acquired
+          # at VOLUME creation, so `flyctl volumes create` is what hits
+          # "failed_precondition: ... insufficient CPUs available" when iad is
+          # momentarily full (2026-06-22 run 27921322176). Retry it with the
+          # same policy as the machine step below.
+          #
+          # Also: capture the create output to a file and check the exit code
+          # explicitly. The previous `VOL_ID=$(flyctl ... | jq)` form let the
+          # pipe mask a failed create — jq returned empty from the error text,
+          # the pipeline exit was jq's (0), so the step went green with an empty
+          # volume id and the machine step later failed with the opaque
+          # "not enough unattached volumes for ''".
           NAME="dbs_stage_${GITHUB_RUN_ID}"
-          VOL_ID=$(flyctl volumes create "$NAME" \
-            --app "$FLY_APP" \
-            --size "$STAGING_VOL_GB" \
-            --region "$FLY_REGION" \
-            --yes \
-            --json \
-            | jq -r '.id')
+          VOL_ID=""
+          for attempt in 1 2 3 4 5; do
+            set +e
+            flyctl volumes create "$NAME" \
+              --app "$FLY_APP" \
+              --size "$STAGING_VOL_GB" \
+              --region "$FLY_REGION" \
+              --yes \
+              --json > /tmp/vol_create.log 2>&1
+            rc=$?
+            set -e
+            cat /tmp/vol_create.log
+            if [ "$rc" -eq 0 ]; then
+              VOL_ID=$(jq -r '.id // empty' /tmp/vol_create.log)
+            fi
+            [ -n "$VOL_ID" ] && break
+            if grep -qiE 'insufficient (cpus|capacity)|capacity hold failed|failed_precondition|no capacity available' /tmp/vol_create.log; then
+              echo "::warning::staging volume create hit Fly capacity (attempt $attempt/5, rc=$rc); retrying after backoff"
+              sleep $((attempt * 30))
+              continue
+            fi
+            echo "flyctl volumes create failed with a non-capacity error (rc=$rc); not retrying" >&2
+            exit 1
+          done
+          if [ -z "$VOL_ID" ]; then
+            echo "Could not create staging volume after 5 attempts (Fly capacity?)" >&2
+            exit 1
+          fi
           echo "id=$VOL_ID" >> $GITHUB_OUTPUT
           echo "Created staging volume: $NAME ($VOL_ID)"
 

--- a/scripts/pull-from-r2-direct.sh
+++ b/scripts/pull-from-r2-direct.sh
@@ -26,9 +26,17 @@ cd /data
 
 for name in "$@"; do
   echo "Pulling $BASE/$name"
+  # -O "$name" forces the output path and OVERWRITES. Without it, wget's
+  # default is to write "$name.1" when "$name" already exists — which it does
+  # for internal.db: the staging machine boots datasette against the fresh
+  # volume before this pull runs, and datasette auto-creates an empty
+  # /data/internal.db. The shipped catalog then landed as internal.db.1 and was
+  # never read, so every db listed 0 tables (run 27922292539). -O also keeps
+  # one canonical file across retries instead of accumulating .1/.2 suffixes.
   wget --user-agent="warehouse-fly-pull/1.0" \
        --tries=5 \
        --no-verbose \
+       -O "$name" \
        "$BASE/$name"
 done
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -33,6 +33,23 @@ while True:
             sys.exit(1)
         time.sleep(2)
 
+# DIAGNOSTIC: read the shipped /data/internal.db directly (separate sqlite
+# connection from datasette) to see whether the frozen catalog is being
+# reused or re-populated. If catalog_databases has each db at schema_version
+# 0 with a populated catalog_tables, reuse SHOULD skip live introspection.
+try:
+    import sqlite3
+    ic = sqlite3.connect("file:/data/internal.db?mode=ro", uri=True)
+    print("--- internal.db catalog_databases (name | schema_version | path) ---")
+    for r in ic.execute("select database_name, schema_version, path from catalog_databases order by 1"):
+        print(f"    {r[0]:>30} | sv={r[1]} | {r[2]}")
+    print("--- internal.db catalog_tables counts ---")
+    for r in ic.execute("select database_name, count(*) from catalog_tables group by 1 order by 1"):
+        print(f"    {r[0]:>30} | {r[1]} tables")
+    ic.close()
+except Exception as e:
+    print(f"    (could not read /data/internal.db: {e})")
+
 versions_body, t = get("/-/versions.json")
 print(f"/-/versions.json   {len(versions_body):>7} bytes  {t:>6.0f} ms")
 
@@ -65,7 +82,11 @@ if missing:
 # in the offline build gate.
 empty = []
 for name in sorted(got):
-    body, t = get(f"/{name}.json?_size=0", timeout=60)
+    # 300s: a cold first render of the cats db landing page (282 tables) can
+    # take minutes if datasette re-populates the catalog (282 per-table
+    # column-detail queries on a cold 433 MB file). On staging there's no
+    # public traffic to race, so let it finish rather than tail-fail.
+    body, t = get(f"/{name}.json?_size=0", timeout=300)
     ntables = len(json.loads(body).get("tables", []))
     print(f"  /{name:>30}.json?_size=0   {t:>6.0f} ms  ({ntables} tables)")
     if ntables == 0:


### PR DESCRIPTION
Follow-ups that make the offline-internal.db refresh actually promote (verified: run 27953220776 promoted, prod /cats lists all 282 tables).

- Staging volume create: retry on Fly capacity + fail loud (was swallowing the error and emitting an empty volume id).
- pull-from-r2: `wget -O` so the shipped internal.db overwrites datasette's auto-created empty one (was landing as internal.db.1).
- smoke-test: 300s per-db timeout (a cold 282-table db-landing-page render takes ~29s; 60s tail-failed) + a diagnostic that dumps the shipped catalog_databases. Confirmed the frozen catalog IS reused (paths untouched); the cost is render, not introspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)