### PR TITLE
query-concurrency: bounded-wait queue (don't 429 cheap concurrent bursts)

### DIFF
--- a/datasette.duckdb.yml
+++ b/datasette.duckdb.yml
@@ -40,14 +40,19 @@ plugins:
     # ROLLBACK: to revert to per-instance mode set `shared_instance: false` AND
     # `memory_limit: 128MB` together (a 1.4GB *per-instance* cap would OOM).
   query-concurrency:
-    # Global in-flight cap on custom-SQL (?sql=) execution. The shared instance
-    # serializes heavy queries through one threads=1 master on a 1-vCPU box, so
-    # without a cap a single automated client starves the whole site (it 524'd
-    # 2026-06-22). Excess heavy queries get an immediate 429 + Retry-After
-    # instead of forming an unbounded queue. Non-SQL traffic is never gated.
-    # 3 == num_sql_threads (the real ceiling); set 2 to always reserve a worker
-    # thread for browsing. See plugins/query_concurrency.py.
+    # Bounded-wait cap on custom-SQL (?sql= on .json/.csv) execution. The shared
+    # instance serializes heavy queries through one threads=1 master on a 1-vCPU
+    # box, so without a cap a single automated client starves the whole site (it
+    # 524'd 2026-06-22). max_concurrent run at once; when full, a request WAITS
+    # up to queue_wait for a slot before getting 429 + Retry-After. Cheap bursts
+    # (e.g. notes.labordata chart pages firing ~6 concurrent ?sql=) free slots
+    # in ms and drain through the wait; only genuinely heavy load holds slots
+    # past queue_wait and sheds. max_queue bounds waiters. Non-SQL traffic and
+    # HTML query pages are never gated. See plugins/query_concurrency.py.
+    # 3 == num_sql_threads (the real ceiling); set 2 to reserve a browse thread.
     max_concurrent: 3
+    queue_wait: 1.5
+    max_queue: 20
     retry_after: 5
   datasette-block-robots:
     literal: |-

--- a/plugins/query_concurrency.py
+++ b/plugins/query_concurrency.py
@@ -8,54 +8,73 @@ until they blow past Cloudflare's ~100s origin timeout and 524. (2026-06-22:
 a `research/1.0` agent doing OSHA analysis took the whole site down this way.)
 
 This gates ONLY machine-format custom-SQL execution — a non-empty `sql=` param
-on a `.json`/`.csv` path — with a global in-flight cap: once `max_concurrent`
-are running, further ones get an immediate `429 + Retry-After` instead of
-forming an unbounded queue. Everything else is untouched, so the box stays
+on a `.json`/`.csv` path. Everything else is untouched, so the box stays
 responsive: table pages, /cats, static, /-/versions, and crucially the HTML
-query pages (`/db/-/query?sql=`) — those are humans writing SQL interactively,
-who run one query at a time and should never be 429'd mid-edit. The flood this
-sheds is programmatic (the 2026-06-22 agent was ~entirely `.json`).
+query pages (`/db/-/query?sql=`) — those are humans writing SQL interactively
+and must never be 429'd mid-edit. The flood this sheds is programmatic.
 
-A concurrency cap (not a req/min rate) is self-tuning to actual load: the slot
-is held for the FULL request, so cheap queries release it in milliseconds
-(high throughput, nobody shed) while expensive ones hold it (the next heavy
-query is shed precisely because the box is busy). No loadavg polling needed.
+## Bounded-wait queue (not a hard reject)
+
+A flat "N concurrent, else 429" cap can't tell a page firing 6 *cheap* cross-
+origin queries (each ~50ms) from one client firing 6 *heavy* joins — it counts
+both on arrival and 429s the excess, breaking legit multi-query pages (e.g. the
+charts on notes.labordata.bunkum.us, which fan out ~6 concurrent `?sql=`
+fetches).
+
+So instead of rejecting on arrival, a request that finds all slots full WAITS
+up to `queue_wait` seconds for one to free before giving up with a 429. Because
+the slot is held for the whole request, the hold time IS the cost signal:
+
+  - cheap burst (box idle): N run in ~50ms, the rest wait ~50ms, slots free,
+    they run — all 200, page renders. The wait drains.
+  - heavy flood: N run for seconds, the rest wait `queue_wait` and the slots
+    DON'T free → 429. Still shed.
+
+`max_queue` bounds how many may wait, so a flood can't pile up unbounded held
+connections (beyond it → immediate 429). Honest limit: if the box is ALREADY
+pegged by a heavy flood, a cheap query arriving then still waits and 429s — you
+can't guarantee a cheap query on a genuinely-saturated 1-vCPU box. The common
+case (page loads against an idle/cheap-loaded box) is fully handled.
 
 Why global, not per-client: the resource is singular (one vCPU / one master),
-so the global count IS the resource model; per-client fairness is a separate
-concern better handled at the edge (it sees IP/UA/bot-score; rotation across
-IPs defeats per-client here anyway). Single uvicorn worker => a module-global
-counter is authoritative.
+so the global count IS the resource model; per-client fairness belongs at the
+edge (IP/UA/bot-score; IP rotation defeats per-client here anyway). Single
+uvicorn worker => module-global state is authoritative.
 
-The 429 is rendered through datasette's own error machinery — Response.json
-for .json clients, otherwise the site-styled error.html (so it picks up
-extra_css_urls etc.) — matching what datasette.handle_exception does. Drop a
-`429.html` template in the template dir to customise it (e.g. add an
-auto-refresh); datasette prefers `<status>.html` over `error.html`.
+The 429 is rendered through datasette's own Response — JSON for .json, text for
+.csv — with Cache-Control AND CDN-Cache-Control: no-store so Cloudflare never
+caches a transient busy response (its labordata cache rule is bypass_by_default,
+which honors no-store).
 
 Config (datasette.yml):
 
     plugins:
       query-concurrency:
-        max_concurrent: 3      # default 3 (= num_sql_threads ceiling)
-        retry_after: 5         # seconds, advertised in the Retry-After header
+        max_concurrent: 3      # running slots (== num_sql_threads ceiling)
+        queue_wait: 1.5        # seconds a full request waits for a slot
+        max_queue: 20          # max waiters before immediate 429
+        retry_after: 5         # advertised in the Retry-After header
 
 `max_concurrent` above num_sql_threads (default 3) has no effect — a query that
 can't get a worker thread waits regardless. Set 2 to always reserve a thread
 for browsing; raise num_sql_threads first to go higher.
 """
 
+import asyncio
 from urllib.parse import parse_qs
 
 from datasette import hookimpl
-from datasette.utils.asgi import Request, Response
+from datasette.utils.asgi import Response
 
-# Process-global in-flight count of custom-SQL requests. The asgi wrapper runs
-# on the single event loop, so the check-then-increment below is atomic (no
-# await between), and one uvicorn worker means this is the whole truth.
-_inflight = 0
+# Module-global limiter state. The asgi wrapper runs on the single uvicorn event
+# loop, so this is authoritative and needs no cross-process coordination. The
+# Semaphore is created lazily on first use (inside a running loop).
+_sem = None
+_waiters = 0
 
 _DEFAULT_MAX = 3
+_DEFAULT_QUEUE_WAIT = 1.5
+_DEFAULT_MAX_QUEUE = 20
 _DEFAULT_RETRY_AFTER = 5
 
 _MESSAGE = (
@@ -71,10 +90,7 @@ def _is_gated(scope):
 
     HTML query pages (``/db/-/query?sql=`` with no data extension) are
     deliberately NOT gated — those are humans writing SQL interactively in the
-    browser, and a person should never get a 429 mid-edit. They run one query
-    at a time anyway. The flood we're shedding is programmatic (the 2026-06-22
-    agent was ~entirely ``.json``), so scoping to .json/.csv targets exactly
-    the automated path and leaves the human-facing UI alone.
+    browser, and a person should never be 429'd mid-edit.
     """
     path = scope.get("path", "")
     if not (path.endswith(".json") or path.endswith(".csv")):
@@ -83,36 +99,25 @@ def _is_gated(scope):
     return any(v.strip() for v in qs.get("sql", []))
 
 
-async def _send_busy(datasette, scope, receive, send, retry_after):
-    info = {
-        "ok": False,
-        "error": _MESSAGE,
-        "status": 429,
-        "title": "Database busy",
-    }
+async def _send_busy(scope, send, retry_after):
     # Never let a transient busy response be cached: a cached 429 would serve
     # "busy" to everyone even when the box is idle. Set both Cache-Control and
     # CDN-Cache-Control (Cloudflare prefers the latter when present) to no-store.
-    # cdn_cache.py only tags 2xx, so it won't re-add a long TTL here.
     headers = {
         "retry-after": str(retry_after),
         "cache-control": "no-store",
         "cdn-cache-control": "no-store",
     }
-    path = scope.get("path", "")
-    if path.endswith(".json"):
-        response = Response.json(info, status=429, headers=headers)
-    elif path.endswith(".csv"):
+    if scope.get("path", "").endswith(".csv"):
         response = Response.text(
             "429 Too Many Requests\n\n" + _MESSAGE + "\n", status=429, headers=headers
         )
     else:
-        # Mirror datasette.handle_exception: prefer <status>.html, fall back to
-        # error.html, rendered via datasette so the page is styled like the site.
-        html = await datasette.render_template(
-            ["429.html", "error.html"], info, request=Request(scope, receive)
+        response = Response.json(
+            {"ok": False, "status": 429, "error": _MESSAGE},
+            status=429,
+            headers=headers,
         )
-        response = Response.html(html, status=429, headers=headers)
     await response.asgi_send(send)
 
 
@@ -120,27 +125,46 @@ async def _send_busy(datasette, scope, receive, send, retry_after):
 def asgi_wrapper(datasette):
     config = datasette.plugin_config("query-concurrency") or {}
     max_concurrent = int(config.get("max_concurrent", _DEFAULT_MAX))
+    queue_wait = float(config.get("queue_wait", _DEFAULT_QUEUE_WAIT))
+    max_queue = int(config.get("max_queue", _DEFAULT_MAX_QUEUE))
     retry_after = int(config.get("retry_after", _DEFAULT_RETRY_AFTER))
 
     def wrap(app):
         async def inner(scope, receive, send):
             # Only gate real HTTP custom-SQL executions; everything else
-            # (table/db pages, static, /-/versions, lifespan, websockets) flows
-            # straight through and is never shed.
+            # (table/db pages, static, /-/versions, HTML query pages, lifespan,
+            # websockets) flows straight through and is never shed.
             if scope.get("type") != "http" or not _is_gated(scope):
                 await app(scope, receive, send)
                 return
 
-            global _inflight
-            if _inflight >= max_concurrent:
-                await _send_busy(datasette, scope, receive, send, retry_after)
+            global _sem, _waiters
+            if _sem is None:
+                _sem = asyncio.Semaphore(max_concurrent)
+
+            # All slots full and the wait queue is also full: shed now rather
+            # than hold yet another connection open.
+            if _sem.locked() and _waiters >= max_queue:
+                await _send_busy(scope, send, retry_after)
                 return
 
-            _inflight += 1
+            # Wait (briefly) for a slot. A cheap burst frees slots within
+            # milliseconds so waiters drain; a heavy flood holds them past
+            # queue_wait and the waiter is shed. (Py3.12 cancels acquire cleanly
+            # on timeout, so no semaphore leak.)
+            _waiters += 1
+            try:
+                await asyncio.wait_for(_sem.acquire(), timeout=queue_wait)
+            except asyncio.TimeoutError:
+                await _send_busy(scope, send, retry_after)
+                return
+            finally:
+                _waiters -= 1
+
             try:
                 await app(scope, receive, send)
             finally:
-                _inflight -= 1
+                _sem.release()
 
         return inner
 


### PR DESCRIPTION
Follow-up to #35. The hard cap 429'd on arrival, breaking pages that fan out several cheap concurrent `?sql=` fetches (e.g. notes.labordata chart pages — confirmed they could 429).

Now a full request **waits up to `queue_wait` (1.5s) for a slot** before 429. Slot-hold time is the cost signal: cheap bursts free slots in ms and drain (all 200); heavy floods hold them past the wait and shed. `max_queue` (20) bounds waiters.

Validated locally (cap=2): 8 concurrent cheap → all 200 (queue drains in waves); 6 concurrent heavy → 2 admitted, 4 get 429 at ~1.5s. HTML query pages still exempt; 429 still uncacheable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)