### PR TITLE
Fix 500 on the blank custom-SQL query form

### DIFF
--- a/templates/query.html
+++ b/templates/query.html
@@ -46,14 +46,14 @@
     {% if not hide_sql %}
         {% if editable and allow_execute_sql %}
             <p><textarea id="sql-editor" name="sql"{% if query and query.sql %} style="height: {{ query.sql.split("\n")|length + 2 }}em"{% endif %}
-            >{% if query and query.sql %}{{ query.sql }}{% else %}select * from {{ tables[0].name|escape_sqlite }}{% endif %}</textarea></p>
+            >{% if query and query.sql %}{{ query.sql }}{% elif tables %}select * from {{ tables[0].name|escape_sqlite }}{% endif %}</textarea></p>
         {% else %}
             <p><textarea id="sql-editor" readonly>{% if query %}{{ query.sql }}{% endif %}</textarea></p>
         {% endif %}
     {% else %}
         {% if not canned_query %}
             <input type="hidden" name="sql"
-                value="{% if query and query.sql %}{{ query.sql }}{% else %}select * from {{ tables[0].name|escape_sqlite }}{% endif %}"
+                value="{% if query and query.sql %}{{ query.sql }}{% elif tables %}select * from {{ tables[0].name|escape_sqlite }}{% endif %}"
             >
         {% endif %}
     {% endif %}


### PR DESCRIPTION
The bare `/db/-/query` form (no `sql`) has 500'd since the DuckDB cutover — the backend refactor dropped several `if sql` guards upstream has. Surfaced by SemrushBot crawling `/_memory/-/query` + our now-stricter error-watch.

Fork side (fgregg/datasette@f1bf5537): None-guards in `rewrite_named_parameters`, restore `if sql` guards at both `validate_sql_select` call-sites.

This repo: `query.html` empty-editor placeholder used `{% else %}select * from {{ tables[0].name }}`, which 500s for a tables-less db like `_memory`. Switch to upstream's `{% elif tables %}`. (Rebased onto main so it keeps the build-43 `_stream=on` fix.)

Verified: blank form (HTML + .json), `_memory`, real queries, named params all 200; invalid SQL still 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)