### PR TITLE
sitemap: timezone-qualified <lastmod> (fix Search Console invalid date)

### DIFF
--- a/plugins/sitemap.py
+++ b/plugins/sitemap.py
@@ -1,3 +1,4 @@
+import re
 from xml.sax.saxutils import escape
 
 from datasette import hookimpl
@@ -5,15 +6,29 @@ from datasette.utils.asgi import Response
 
 INTERNAL_DATABASES = {"_internal", "_memory"}
 
+# A trailing timezone designator: Z or ±hh:mm / ±hhmm.
+_HAS_TZ = re.compile(r"(?:Z|[+-]\d{2}:?\d{2})$")
+
 
 def _iso_datetime(value):
-    """Normalize a SQLite date/datetime scalar to ISO 8601 for <lastmod>."""
+    """Normalize a date/datetime scalar to a sitemap-valid W3C datetime.
+
+    Per the sitemaps spec <lastmod> must be either a date (YYYY-MM-DD) or a
+    *full* datetime carrying a timezone. The warehouse hands us naive UTC
+    timestamps like '2026-04-22 17:14:37' (no zone), which Search Console
+    rejects as an invalid date. So: swap the separator, drop any fractional
+    seconds, and stamp UTC — while leaving date-only and already-zoned values
+    untouched.
+    """
     s = str(value).strip()
     if not s:
         return None
-    if " " in s and "T" not in s:
-        s = s.replace(" ", "T", 1)
-    return s
+    s = s.replace(" ", "T", 1)
+    if "T" not in s:
+        return s  # date-only is already valid
+    if _HAS_TZ.search(s):
+        return s  # already carries a timezone
+    return s.split(".", 1)[0] + "Z"
 
 
 async def _db_lastmod(datasette, name, db):


### PR DESCRIPTION
## Problem
Google Search Console rejects the sitemap: *"An invalid date was found"* on `<lastmod>` tags.

The values look like `2026-04-22T17:14:37` — a time-of-day with **no timezone**. The [sitemaps spec](https://www.sitemaps.org/protocol.html#lastmoddef) requires `<lastmod>` to be a [W3C Datetime](https://www.w3.org/TR/NOTE-datetime): either `YYYY-MM-DD` or a full datetime **carrying a timezone** (`Z` or `±hh:mm`). A zoneless datetime is invalid.

## Cause
`plugins/sitemap.py:_iso_datetime` only swapped the space separator for `T`; it never added a zone. The warehouse hands it naive UTC timestamps (from each db's `date_modified_sql`), so they emitted without a `Z`.

## Fix
Stamp UTC when a full datetime lacks a zone (the warehouse's timestamps are UTC — same convention as the atom feeds' `strftime(...'%Y-%m-%dT%H:%M:%SZ')`), drop any fractional seconds, and leave date-only / already-zoned values untouched. Verified against the real cases:

| input | output |
|---|---|
| `2026-04-22 17:14:37` | `2026-04-22T17:14:37Z` |
| `2026-04-22T17:14:37.123456` | `2026-04-22T17:14:37Z` |
| `2026-04-22` | `2026-04-22` (unchanged) |
| `2026-04-22T17:14:37+00:00` | unchanged |

After merge → deploy, re-submit the sitemap in Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)